### PR TITLE
Introduced image editing to the JS API

### DIFF
--- a/AIQJSBridge.podspec
+++ b/AIQJSBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AIQJSBridge'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = "Provides JavaScript access to AppearIQ cloud services."
   s.homepage         = "https://github.com/appear/AIQJSBridge"
   s.license          = 'MIT'
@@ -17,8 +17,9 @@ Pod::Spec.new do |s|
   }
 
   s.public_header_files = 'Pod/Classes/**/AIQ*.h'
-  s.dependency 'AIQCoreLib', '~> 1.5.2'
+  s.dependency 'AIQCoreLib', '~> 1.5.3'
   s.dependency 'Google/Analytics'
+  s.dependency 'CLImageEditor'
 
   s.subspec 'Cordova' do |ss|
     ss.source_files = 'Cordova/Classes/**/*'

--- a/Pod/Assets/plugins/aiq-plugin-imaging/www/imaging.js
+++ b/Pod/Assets/plugins/aiq-plugin-imaging/www/imaging.js
@@ -1,4 +1,4 @@
-cordova.define('aiq-plugin-imaging', function(require, exports, module) {
+cordova.define('aiq-plugin-imaging', function (require, exports, module) {
     var exec = require('cordova/exec');
     var core = require('aiq-plugin-core');
 
@@ -6,7 +6,7 @@ cordova.define('aiq-plugin-imaging', function(require, exports, module) {
         // Empty constructor
     }
     
-    Imaging.prototype.capture = function(idOrSettings, settingsOrNil) {
+    Imaging.prototype.capture = function (idOrSettings, settingsOrNil) {
         console.warn('aiq.imaging.capture() is deprecated, use navigator.camera.getPicture() isntead');
         var settings;
         var id;
@@ -20,6 +20,18 @@ cordova.define('aiq-plugin-imaging', function(require, exports, module) {
             settings = idOrSettings || {};
         }
         exec(settings.success, core._proxyError(settings), 'AIQImaging', 'capture', [false, settings.source, id]);
+    };
+
+    Imaging.prototype.edit = function (imageUri, settingsOrNil) {
+        var settings = settingsOrNil || {};
+        settings.failure = settings.failure || function () {};
+
+        if (typeof settings.success !== 'function') {
+            console.error('No success callback provided, or not callable');
+            return;
+        }
+
+        exec(settings.success, settings.failure, 'AIQImaging', 'edit', [imageUri]);
     };
 
     module.exports = new Imaging();

--- a/Pod/Classes/AIQImagingPlugin.h
+++ b/Pod/Classes/AIQImagingPlugin.h
@@ -3,5 +3,6 @@
 @interface AIQImagingPlugin : AIQPlugin
 
 - (void)capture:(CDVInvokedUrlCommand *)command;
+- (void)edit:(CDVInvokedUrlCommand *)command;
 
 @end


### PR DESCRIPTION
**Note**: This PR depends on another one I made on the AIQCoreLib repo: https://github.com/appear/AIQCoreLib/pull/1

This adds a new JS API endpoint for graphically editing images:

``` javascript
aiq.imaging.edit(imagePath, callbacks);
```

where `imagePath` is the full path to an image on the device and `callbacks` is an object containing callbacks:

``` javascript
var callbacks = {
  success: function (imageData) {
    // This property has to be here, and it has to be callable
    // imageData has two properties:
    var contentType = imageData.contentType;
    var editedImagePath = imageData.resourceUrl;
  },
  failure: function () {
    // This is an optional property
  }
};
```

**Note**: the original image will not be altered. A new image will be created based on the user's edits and saved to a temporary directory on the device. 
